### PR TITLE
Updated chunkEventStream.js to allow for skips

### DIFF
--- a/lib/stream/helper/chunkEventStream.js
+++ b/lib/stream/helper/chunkEventStream.js
@@ -122,8 +122,8 @@ module.exports = function(ls, event, opts) {
 			if (!record.payload && record.correlation_id) {
 				updateStats(record.id, record);
 				updateCorrelation(record.correlation_id);
-				done();
-				return;
+				item.records++;
+  				return done(null, {});
 			}
 
 			if (record.s3) {


### PR DESCRIPTION
To allow for skipping of events (shipping science needed this since many events are skipped in some cases).  This new way will still checkpoint when it skips