### PR TITLE
Remove wrapper on subsequent calls

### DIFF
--- a/lib/stream/leo-stream.js
+++ b/lib/stream/leo-stream.js
@@ -1475,7 +1475,7 @@ module.exports = function(configure) {
 									retry.fail(err);
 								}
 							} else if (table in data.UnprocessedItems && Object.keys(data.UnprocessedItems[table]).length !== 0) {
-								records = data.UnprocessedItems[table];
+								records = data.UnprocessedItems[table].map(m => m.PutRequest.Item);
 								retry.backoff();
 							} else {
 								logger.info("saved");


### PR DESCRIPTION
When retrying, records has the PutRequest.Item wrapper around it so it is failing.  This needs to be stripped.