### PR TITLE
support for deduping by passing in range and hash

### DIFF
--- a/lib/stream/leo-stream.js
+++ b/lib/stream/leo-stream.js
@@ -1416,7 +1416,27 @@ module.exports = function(configure) {
 			var records, size;
 
 			function reset() {
-				records = [];
+				if (opts.hash || opts.range) {
+					let key = opts.range ? (obj) => {
+						return `${obj[opts.hash]}-${obj[opts.range]}`;
+					} : (obj) => {
+						return `${obj[opts.hash]}`;
+					};
+
+					records = {
+						length: 0,
+						data: {},
+						push: function(obj) {
+							this.data[key(obj)] = obj;
+							this.length++;
+						},
+						map: function(each) {
+							return Object.keys(this.data).map(key => each(this.data[key]));
+						}
+					};
+				} else {
+					records = [];
+				}
 			}
 			reset();
 
@@ -1475,7 +1495,8 @@ module.exports = function(configure) {
 									retry.fail(err);
 								}
 							} else if (table in data.UnprocessedItems && Object.keys(data.UnprocessedItems[table]).length !== 0) {
-								records = data.UnprocessedItems[table].map(m => m.PutRequest.Item);
+								reset();
+								data.UnprocessedItems[table].map(m => records.push(m.PutRequest.Item));
 								retry.backoff();
 							} else {
 								logger.info("saved");


### PR DESCRIPTION
This is the fix Clint gave me and I have been running in prod for a bit - just need in it published.  It makes it so the toDynamoDB function will support deduping.