### PR TITLE
Removed .done()

### DIFF
--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -212,7 +212,7 @@ module.exports = function(configure) {
 									resolve(data)
 								}).catch(function(err) {
 									reject(err);
-								}).done();
+								});
 
 							} else {
 								data._stats = stats;


### PR DESCRIPTION
Clint said that this .done() is an artifact from the old q promised (per https://dropship.atlassian.net/browse/LEO-171) - he said "the old version of promises we used was "q" and it required a .done() to terminate the chain. The build in Promises in node don't require the .done()"

Therefore, I don't think we need it, and it is breaking us.