### PR TITLE
Remove .done() that is causing errors

### DIFF
--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -212,7 +212,7 @@ module.exports = function(configure) {
 									resolve(data)
 								}).catch(function(err) {
 									reject(err);
-								}).done();
+								});
 
 							} else {
 								data._stats = stats;


### PR DESCRIPTION
Clint said that this .done() is an artifact from the old q promised (per https://dropship.atlassian.net/browse/LEO-171) - he said "the old version of promises we used was "q" and it required a .done() to terminate the chain. The build in Promises in node don't require the .done()"

Therefore, I don't think we need it, and it is breaking us.

I am currently getting:

[ '/Users/mrn3/Downloads/dsco/search' ]
Tue, 05 Jun 2018 16:59:23 GMT uncaughtException: query(...).then(...).catch(...).done is not a function
TypeError: query(...).then(...).catch(...).done is not a function
at /Users/mrn3/Downloads/dsco/node_modules/leo-sdk/lib/dynamodb.js:215:12
at Object.progress (/Users/mrn3/Downloads/dsco/node_modules/leo-sdk/lib/dynamodb.js:180:6)
at Response.<anonymous> (/Users/mrn3/Downloads/dsco/node_modules/leo-sdk/lib/dynamodb.js:198:14)
at Request.<anonymous> (/Users/mrn3/Downloads/dsco/search/node_modules/aws-sdk/lib/request.js:364:18)
at Request.callListeners (/Users/mrn3/Downloads/dsco/search/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
at Request.emit (/Users/mrn3/Downloads/dsco/search/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
at Request.emit (/Users/mrn3/Downloads/dsco/search/node_modules/aws-sdk/lib/request.js:683:14)
at Request.transition (/Users/mrn3/Downloads/dsco/search/node_modules/aws-sdk/lib/request.js:22:10)
at AcceptorStateMachine.runTo (/Users/mrn3/Downloads/dsco/search/node_modules/aws-sdk/lib/state_machine.js:14:12)
at /Users/mrn3/Downloads/dsco/search/node_modules/aws-sdk/lib/state_machine.js:26:10

I removed the .done() locally and it made it work, but not sure if that is the right thing to do