### PR TITLE
fix for bad reference to data.took

### DIFF
--- a/connectors/elasticsearch/toES.js
+++ b/connectors/elasticsearch/toES.js
@@ -382,7 +382,7 @@ module.exports = function(configure) {
 							console.timeEnd(index + "es_bulk");
 							console.log(index, !err && data.took);
 
-							lastDuration = Math.max(lastDuration, data.took);
+							lastDuration = Math.max(lastDuration, data && data.took);
 							if (err || data.errors) {
 								if (data && data.Message) {
 									err = data.Message;


### PR DESCRIPTION
This is a fix for https://dropship.atlassian.net/browse/LEO-251 - when data.took is referenced but data doesn't exist when there is an error.