### PR TITLE
Gzip DSCO LEO-172 bug fix

### DIFF
--- a/lib/stream/leo-stream.js
+++ b/lib/stream/leo-stream.js
@@ -1342,6 +1342,10 @@ module.exports = function(configure) {
 												var eid = 0;
 												let s3Stream = ls.fromS3(file);
 												let gzipStream = zlib.createGunzip();
+												gzipStream.setEncoding('utf8');
+												gzipStream.on('error', function(err) {
+													logger.debug("Skipping gzip");
+												});
 												pump(s3Stream, gzipStream, split((value) => {
 													try {
 														return {
@@ -1387,7 +1391,11 @@ module.exports = function(configure) {
 											delete item.kinesis_number;
 											// v1 getEvents already unzipped the payload
 											if (item.gzip && leoEvent.v >= 2) {
-												item.payload = JSON.parse(zlib.gunzipSync(item.payload));
+												try {
+													item.payload = JSON.parse(zlib.gunzipSync(item.payload).toString());
+												} catch (e) {
+													item.payload = {};
+												}
 											} else if (typeof item.payload === "string") {
 												item.payload = JSON.parse(item.payload);
 											}
@@ -1401,6 +1409,10 @@ module.exports = function(configure) {
 											}
 										} else if (item.gzip) {
 											var gzip = zlib.createGunzip();
+											gzip.setEncoding('utf8');
+											gzip.on('error', function(err) {
+												logger.debug("Skipping gzip");
+											});
 											pump(gzip, split(JSON.parse), ls.write((e, done) => {
 												e.eid = createEId(e.eid);
 												if (!isPassDestroyed && e.eid.localeCompare(start) > 0 && totalCount < opts.limit && totalSize < opts.size) { //Then it is greater than the event they were looking at

--- a/lib/stream/leo-stream.js
+++ b/lib/stream/leo-stream.js
@@ -947,7 +947,8 @@ module.exports = function(configure) {
 								records: u.records,
 								source_timestamp: u.source_timestamp,
 								ended_timestamp: u.timestamp,
-								started_timestamp: u.timestamp
+								started_timestamp: u.timestamp,
+								force: opts.force
 							};
 						} else {
 							c[event].eid = u.end;

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -131,7 +131,7 @@ let ls = module.exports = {
 	},
 	buffer: (opts, each, emit, flush) => {
 		opts = merge({
-			time: {
+			time: opts && opts.time ||  {
 				seconds: 10
 			},
 			size: 1024 * 200,


### PR DESCRIPTION
1. Suppresses Z_BUF_ERROR messages
2. Sets stream to UTF-8 before decompressing, reducing the likelihood of multi-byte chunk boundary errors.