### PR TITLE
Fix creating empty s3 files

### DIFF
--- a/lib/stream/helper/chunkEventStream.js
+++ b/lib/stream/helper/chunkEventStream.js
@@ -79,8 +79,8 @@ module.exports = function(ls, event, opts) {
 			buffer: opts.buffer,
 			debug: opts.debug
 		}, function write(record, done) {
-			let timestamp = record.timestamp || Date.now();
-			let start = (record.event_source_timestamp || timestamp);
+			let timestamp = record.timestamp = record.timestamp || Date.now();
+			let start = record.event_source_timestamp = (record.event_source_timestamp || timestamp);
 
 			function updateStats(id, stats) {
 				if (!(id in item.stats)) {
@@ -134,9 +134,7 @@ module.exports = function(ls, event, opts) {
 
 			//If there is no payload but there is a correlation_id then we just need to skip this record but store the checkpoint as processed
 			if ((!record.payload || record.dont_write === true) && record.correlation_id) {
-				updateStats(record.id, record);
 				updateCorrelation(record.correlation_id);
-				item.records++;
 				done(null, {});
 				return;
 			}
@@ -204,7 +202,7 @@ module.exports = function(ls, event, opts) {
 		},
 		function emit(done, data) {
 			emitChunk(data.isLast, (value) => {
-				if (value && value.records) {
+				if (value && value.correlations && Object.keys(value.correlations).length) {
 					this.push(value);
 				}
 				done();

--- a/lib/stream/helper/leos3.js
+++ b/lib/stream/helper/leos3.js
@@ -40,7 +40,7 @@ module.exports = function(ls, queue, configure, opts, onFlush) {
 				logger.error(err);
 				done(err);
 			} else {
-				if (evnt.records > 0) {
+				if (evnt.correlations.length) {
 					push(evnt);
 				}
 				done();
@@ -65,6 +65,7 @@ module.exports = function(ls, queue, configure, opts, onFlush) {
 			newFile = `bus/${queue}/z/${timestamp.format("YYYY/MM/DD/HH/mm/")+timestamp.valueOf()}-${postfix}.gz`;
 		}
 
+		logger.info("S3 Location:", newFile);
 		s3 = ls.toS3(configure.resources.LeoS3 || configure.s3, newFile);
 		e = {
 			event: queue,
@@ -100,27 +101,30 @@ module.exports = function(ls, queue, configure, opts, onFlush) {
 			});
 		} else {
 			//The previous stream is ready to be submitted
-			count++;
-			var noBackPressure = s3.write(obj.gzip);
-			delete obj.gzip;
+			var noBackPressure = true;
+			if (!!obj.size) {
+				count++;
+				noBackPressure = s3.write(obj.gzip);
 
-			obj.offset = e.size;
-			obj.gzipOffset = e.gzipSize;
-			if (!opts.archive) {
-				obj.start = e.records + obj.start;
-				obj.end = e.records + obj.end;
-				e.end = obj.end;
-			} else {
-				if (!e.start) {
-					e.start = obj.start;
+				obj.offset = e.size;
+				obj.gzipOffset = e.gzipSize;
+				if (!opts.archive) {
+					obj.start = e.records + obj.start;
+					obj.end = e.records + obj.end;
+					e.end = obj.end;
+				} else {
+					if (!e.start) {
+						e.start = obj.start;
+					}
+					e.end = obj.end;
+					e.archive = true;
 				}
-				e.end = obj.end;
-				e.archive = true;
-			}
 
-			e.size += obj.size;
-			e.gzipSize += obj.gzipSize;
-			e.records += obj.records;
+				e.size += obj.size;
+				e.gzipSize += obj.gzipSize;
+				e.records += obj.records;
+				e.offsets.push(obj);
+			}
 
 			for (var botid in obj.stats) {
 				if (!(botid in e.stats)) {
@@ -136,9 +140,9 @@ module.exports = function(ls, queue, configure, opts, onFlush) {
 			}
 			e.correlations = e.correlations.concat(obj.correlations);
 
+			delete obj.gzip;
 			delete obj.stats;
 			delete obj.correlations;
-			e.offsets.push(obj);
 
 			if (!noBackPressure) {
 				s3.once('drain', () => {


### PR DESCRIPTION
Chunk will emit based on existance of correlations instead of record count which allows for reading without writing while still checkpointing
leoS3 will only push a offset if there is data to  write based on byte size instead of record count.  Final emit is based on correlations instead of record count