### PR TITLE
DD-1451 - Update leo-sdk so it won't push empty s3 files

### DIFF
--- a/lib/stream/helper/leos3.js
+++ b/lib/stream/helper/leos3.js
@@ -94,7 +94,7 @@ module.exports = function(ls, queue, configure, opts, onFlush) {
 	}, function(obj, done) {
 		if (obj.s3) {
 			this.flush((err) => {
-				if (!err) {
+				if (!err && !!obj.size) {
 					this.push(obj);
 				}
 				done(err);


### PR DESCRIPTION
If the object has s3 and no size, we should not put an event on