### PR TITLE
DD-1451 - fix emitChunk to consider checksum case

### DIFF
--- a/lib/stream/helper/chunkEventStream.js
+++ b/lib/stream/helper/chunkEventStream.js
@@ -202,7 +202,7 @@ module.exports = function(ls, event, opts) {
 		},
 		function emit(done, data) {
 			emitChunk(data.isLast, (value) => {
-				if (value && value.correlations && Object.keys(value.correlations).length) {
+				if (value && (value.size || (value.correlations && Object.keys(value.correlations).length))) {
 					this.push(value);
 				}
 				done();


### PR DESCRIPTION
In the case of checksums, correlations is not populated, so we need to use the old way and just check value.size