### PR TITLE
EN-17 - Fix bug where exports are not returned

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -26,7 +26,7 @@ module.exports = {
 							exports: code
 						}
 					}
-					return wrap(exports, module);
+					return wrap(module.exports, module);
 				};
 			}
 		} else {


### PR DESCRIPTION
This is a bug where exports are never set properly in the case where code is passed in as module (object).