### PR TITLE
EN-1095 - allows for setting partial_start attribute

### DIFF
--- a/lib/stream/leo-stream.js
+++ b/lib/stream/leo-stream.js
@@ -430,7 +430,7 @@ module.exports = function(configure) {
 								eid: rOpts.eid || obj.eid,
 								correlation_id: {
 									source: obj.event,
-									start: rOpts.eid || obj.eid,
+									[rOpts.partial === true ? 'partial_start' : 'start']: rOpts.eid || obj.eid,
 									units: rOpts.units || obj.units || 1
 								}
 							});


### PR DESCRIPTION
If we pass in partial === true, then we set the partial_start attribute instead of start.  This enables us to do one to many events in the enrich that we need for new lambda load listeners.