### PR TITLE
use the same format for the S3 storage buckets when using a prefix

### DIFF
--- a/lib/stream/helper/leos3.js
+++ b/lib/stream/helper/leos3.js
@@ -60,7 +60,7 @@ module.exports = function(ls, queue, configure, opts, onFlush) {
 		if (opts.archive) {
 			newFile = `bus/_archive/q=${queue}/dt=${timestamp.format("YYYY-MM-DD")}/${timestamp.valueOf()}-${postfix}.gz`;
 		} else if (opts.prefix) {
-			newFile = `bus/${queue}/${opts.prefix}/${timestamp.valueOf()}-${postfix}.gz`;
+			newFile = `bus/${queue}/${opts.prefix}/z/${timestamp.format("YYYY/MM/DD/HH/mm/")+timestamp.valueOf()}-${postfix}.gz`;
 		} else {
 			newFile = `bus/${queue}/z/${timestamp.format("YYYY/MM/DD/HH/mm/")+timestamp.valueOf()}-${postfix}.gz`;
 		}


### PR DESCRIPTION
If we ever need to debug the S3 storage again, we want the same structure as before, but now all files will have the path prefix with the botId before the 'z/2020/...' stuff.