### PR TITLE
Cron checkpoint safety check sets the current checkpoint to the expec…

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -406,6 +406,10 @@ module.exports = function(configure) {
 
 			}
 
+			// Safey check to prevent setting checkpoint to undefined
+			if (checkpointData.checkpoint === undefined){
+				checkpointData.checkpoint = cronCheckpointCommand.ExpressionAttributeValues[":expected"];
+			}
 			logger.info(JSON.stringify(cronCheckpointCommand, null, 2));
 			dynamodb.docClient.update(cronCheckpointCommand, function(err, data) {
 				if (err && err.code == "ConditionalCheckFailedException") {

--- a/lib/stream/helper/leos3.js
+++ b/lib/stream/helper/leos3.js
@@ -1,6 +1,7 @@
 "use strict";
 var moment = require("moment");
 var chunkEventStream = require("./chunkEventStream.js");
+const uuid = require("uuid");
 
 const logger = require('leo-logger')('leoS3');
 
@@ -55,7 +56,7 @@ module.exports = function(ls, queue, configure, opts, onFlush) {
 
 	function newStream() {
 		var timestamp = moment();
-		let postfix = (pad + (++fileCount)).slice(padLength);
+		let postfix = (pad + (++fileCount)).slice(padLength) + "-" + uuid.v4();
 		let newFile;
 		if (opts.archive) {
 			newFile = `bus/_archive/q=${queue}/dt=${timestamp.format("YYYY-MM-DD")}/${timestamp.valueOf()}-${postfix}.gz`;

--- a/lib/stream/leo-stream.js
+++ b/lib/stream/leo-stream.js
@@ -212,15 +212,15 @@ module.exports = function(configure) {
 
 			args.push(ls.through((obj, done) => {
 				var e;
-				if (opts.autoDetectPayload && obj.payload) {
+				if (opts.autoDetectPayload && (obj.payload || obj.correlation_id)) {
 					e = obj;
 				} else {
 					e = {
 						payload: obj
 					};
 				}
-				e.id = id;
-				e.event = outQueue;
+				e.id = e.id || id;
+				e.event = e.event || outQueue;
 				if (!e.event_source_timestamp) {
 					e.event_source_timestamp = moment.now();
 				}
@@ -230,15 +230,16 @@ module.exports = function(configure) {
 				done(null, e);
 			}));
 			if (opts.useS3 && !opts.firehose) {
-				args.push(leoS3(ls, outQueue, configure, {prefix: id}));
-			} else {
+				args.push(leoS3(ls, outQueue, configure, {prefix: opts.prefix || id}));
+			} else if (!opts.firehose) {
+				// TODO: This should be part of auto switch
 				args.push(promiseStreams.throughPromise(async (obj, push) => {
 					let size = Buffer.byteLength(JSON.stringify(obj));
 					if (size > twoHundredK * 3) {
 						logger.info('Sending event to S3 because it exceeds the max size for DDB. ', size);
 						await promiseStreams.pipelineAsync(
 							es.readArray([obj]),
-							leoS3(ls, outQueue, configure),
+							leoS3(ls, outQueue, configure, {prefix: opts.prefix || id}),
 							promiseStreams.passThrough(newobj => {
 								push(newobj);
 							})


### PR DESCRIPTION
…ted value if no checkpoint is passed in

Added uuid.v4() to leoS3 file names so that concurrent streams don't collide on file name

leo.load:
   autoDetectPayload will also look for a correlation_id
   pass the event id and event if they already exist  (allows load to write to multiple queues if using kinesis or firehose)
   fix bug with the auto S3 write when files are too big and using firehose