### PR TITLE
fix error when doing a log message

### DIFF
--- a/lib/stream/leo-stream.js
+++ b/lib/stream/leo-stream.js
@@ -1572,8 +1572,7 @@ module.exports = function(configure) {
 							let free_s3_stream = (index) => {
 								if (s3_streams[index] != null) {
 									bytes -= s3_streams[index].bytes;
-									logger.debug("free s3 connection", items[last_s3_index].s3.key);
-
+									logger.debug("free s3 connection", items[index].s3.key);
 								}
 								delete s3_streams[index];
 							};


### PR DESCRIPTION
It was referencing `last_s3_index` instead of `index`.