### PR TITLE
Adding ability to compress data when delivering to firehose

### DIFF
--- a/lib/lib.d.ts
+++ b/lib/lib.d.ts
@@ -83,6 +83,13 @@ export interface BaseWriteOptions {
 	firehose?: boolean;
 
 	/**
+	 * If true, data sent to firehose will be gzip compressed.
+	 * 
+	 * @default false
+	 */
+	gzipFirehose?: boolean
+
+	/**
 	 * The number of records, where each record is an event, to micro-batch locally in the SDK before writing 
 	 * them to either kinesis, firehose or S3.  See the other options in this object to understand how this 
 	 * might be useful.

--- a/lib/stream/leo-stream.js
+++ b/lib/stream/leo-stream.js
@@ -310,7 +310,7 @@ module.exports = function(configure) {
 				}
 				done(null, e);
 			}));
-			if (opts.useS3 && !opts.firehose) {
+			if (opts.useS3) {
 				args.push(leoS3(ls, outQueue, configure, { prefix: opts.prefix || id }));
 			} else if (!opts.firehose) {
 				// TODO: This should be part of auto switch
@@ -695,7 +695,7 @@ module.exports = function(configure) {
 				}
 			};
 			var type = "kinesis";
-			if (opts.useS3 && !opts.firehose) { //why would both of these be set?
+			if (opts.useS3) {
 				type = "s3";
 			} else if (opts.firehose) {
 				type = "firehose";
@@ -765,7 +765,7 @@ module.exports = function(configure) {
 					logger.time("firehose request");
 					firehose.putRecordBatch({
 						Records: [{
-							Data: records.join('')
+							Data: opts.gzipFirehose ? (records.map(r => r.toString("base64")).join('\n') + '\n') : records.join('')
 						}],
 						DeliveryStreamName: configure.bus.firehose
 					}, function(err, data) {
@@ -849,13 +849,13 @@ module.exports = function(configure) {
 				enableLogging: true,
 				snapshot: opts.snapshot
 			}, opts.chunk || {});
-			chunkOpts.gzip = !opts.firehose;
+			chunkOpts.gzip = opts.gzipFirehose || !opts.firehose;
 
 			let currentQueues = new Set();
 			var p = ls.buffer(opts, function(obj, callback) {
 				if (obj.stats) {
 					Object.values(obj.stats).map(v => {
-						let queues = v.queues;
+						let queues = v.queues || {};
 						// We don't want queues to continue past here, so remove it
 						delete v.queues;
 						return Object.keys(queues);
@@ -887,7 +887,7 @@ module.exports = function(configure) {
 			});
 
 			let streams = [];
-			if (!opts.useS3 && !opts.firehose) {
+			if (!opts.useS3) {
 				streams.push(ls.throughAsync(async (obj, push) => {
 					let size = Buffer.byteLength(JSON.stringify(obj));
 					if (size > twoHundredK * 3) {


### PR DESCRIPTION
Should not be merged until the bus portion has be released.  Otherwise it will send events that can't be processed in firehose