### PR TITLE
ES-2352 - bumped leo-logger version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "leo-sdk",
-	"version": "7.1.8",
+	"version": "7.1.15",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "leo-sdk",
-			"version": "7.1.8",
+			"version": "7.1.15",
 			"license": "MIT",
 			"dependencies": {
 				"async": "2.6.4",
@@ -19,7 +19,7 @@
 				"flush-write-stream": "2.0.0",
 				"ini": "2.0.0",
 				"leo-config": "1.1.0",
-				"leo-logger": "1.0.1",
+				"leo-logger": "1.0.7",
 				"lodash": "4.17.21",
 				"lodash.merge": "^4.6.2",
 				"moment": "2.29.4",
@@ -8602,10 +8602,12 @@
 			"license": "MIT"
 		},
 		"node_modules/leo-logger": {
-			"version": "1.0.1",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/leo-logger/-/leo-logger-1.0.7.tgz",
+			"integrity": "sha512-/72+KNRJfde5PqYXi6RvcT+SUXnsVFLrNzkKoqVBPekNTd332Hf27J5iUzcOr1Oji2bHmD2edKeBq4GKlCk2Ww==",
 			"license": "MIT",
 			"dependencies": {
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.21"
 			}
 		},
 		"node_modules/levn": {
@@ -17458,9 +17460,11 @@
 			}
 		},
 		"leo-logger": {
-			"version": "1.0.1",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/leo-logger/-/leo-logger-1.0.7.tgz",
+			"integrity": "sha512-/72+KNRJfde5PqYXi6RvcT+SUXnsVFLrNzkKoqVBPekNTd332Hf27J5iUzcOr1Oji2bHmD2edKeBq4GKlCk2Ww==",
 			"requires": {
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.21"
 			}
 		},
 		"levn": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "leo-sdk",
-	"version": "7.1.14",
+	"version": "7.1.15",
 	"description": "Load data onto the LEO Platform",
 	"homepage": "https://leoplatform.io",
 	"main": "index.js",
@@ -35,7 +35,7 @@
 		"flush-write-stream": "2.0.0",
 		"ini": "2.0.0",
 		"leo-config": "1.1.0",
-		"leo-logger": "1.0.1",
+		"leo-logger": "1.0.7",
 		"lodash": "4.17.21",
 		"lodash.merge": "^4.6.2",
 		"moment": "2.29.4",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps `leo-logger` to `1.0.7` and updates package version to `7.1.15`.
> 
> - **Dependencies**:
>   - Upgrade `leo-logger` from `1.0.1` to `1.0.7` (updates its `lodash` peer to `^4.17.21`).
> - **Release**:
>   - Bump package version in `package.json` to `7.1.15`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eec44d821bcc7f1319051f6b18b2266d96e1531f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->