### PR TITLE
ES-2352 - fixed getSetting typing

### DIFF
--- a/lib/dynamodb.d.ts
+++ b/lib/dynamodb.d.ts
@@ -15,13 +15,18 @@ interface GetOptions { }
  */
 interface PutOptions { }
 
+interface LeoSettingEntry<T> {
+	id: string;
+	value: T;
+}
+
 /**
  * Helper functions to interact with Dynamo DB.
  * 
  * @todo document functions below
  */
 export interface LeoDynamodb {
-	getSettingPromise: <T>(setting_id: string) => Promise<T>;
+	getSettingPromise: <T>(setting_id: string) => Promise<LeoSettingEntry<T>>;
 	setSettingPromise: <T>(setting_id: string, value: T) => Promise<void>;
 	docClient: DynamoDBDocument,
 	get: <T>(table: string, id: string, opts: GetOptions, callback: DataCallback<AWSError, T>) => void,
@@ -31,7 +36,7 @@ export interface LeoDynamodb {
 	updateMulti: (items, opts, callback) => void,
 	scan: (table: string, filter, callback) => void,
 	saveSetting: <T>(setting_id: string, value: T, callback: Callback<AWSError>) => void,
-	getSetting: <T>(setting_id: string, callback: DataCallback<AWSError, T>) => void,
+	getSetting: <T>(setting_id: string, callback: DataCallback<AWSError, LeoSettingEntry<T>>) => void,
 	query: (params, configuration?, stats?) => Promise<any>,
 	batchGetHashkey: (table: string, hashkey, ids, opts, callback) => void,
 	batchGetTable: (table: string, keys, opts, callback) => void,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "leo-sdk",
-	"version": "7.1.15",
+	"version": "7.1.16",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "leo-sdk",
-			"version": "7.1.15",
+			"version": "7.1.16",
 			"license": "MIT",
 			"dependencies": {
 				"async": "2.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "leo-sdk",
-	"version": "7.1.15",
+	"version": "7.1.16",
 	"description": "Load data onto the LEO Platform",
 	"homepage": "https://leoplatform.io",
 	"main": "index.js",


### PR DESCRIPTION
- the getSetting function actually returns a wrapped value and not a direct T as it was originally typed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects settings API types to return a wrapped `LeoSettingEntry<T>` (with id and value) and bumps version to 7.1.16.
> 
> - **Types (DynamoDB)**:
>   - Add `LeoSettingEntry<T>` with `id` and `value`.
>   - Update settings API signatures to return wrapped entries:
>     - `getSettingPromise<T>` now returns `Promise<LeoSettingEntry<T>>`.
>     - `getSetting<T>` callback now yields `LeoSettingEntry<T>`.
> - **Version**:
>   - Bump package version to `7.1.16`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72fec5ce199b7962ab5556262962c4dc1a4b92a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->