### PR TITLE
fix(stream): handle S3 upload errors without crashing the process

### DIFF
--- a/lib/stream/helper/leos3.js
+++ b/lib/stream/helper/leos3.js
@@ -23,13 +23,19 @@ module.exports = function(ls, queue, configure, opts, onFlush) {
 
 	function submitStream(callback) {
 		if (count > 0) {
-			s3.on("finish", (err) => {
-				if (err) {
-					logger.error(err);
-				} else {
-					logger.debug("UPLOADED FILE");
+			let called = false;
+			s3.on("error", (err) => {
+				if (!called) {
+					called = true;
+					callback(err);
 				}
-				callback(err);
+			});
+			s3.on("finish", () => {
+				if (!called) {
+					called = true;
+					logger.debug("UPLOADED FILE");
+					callback();
+				}
 			});
 			s3.end();
 		} else {
@@ -72,6 +78,9 @@ module.exports = function(ls, queue, configure, opts, onFlush) {
 
 		logger.info("S3 Location:", newFile);
 		s3 = ls.toS3(configure.resources.LeoS3 || configure.s3, newFile);
+		s3.on('error', (err) => {
+			logger.error("S3 upload error for queue '" + queue + "':", err);
+		});
 		e = {
 			event: queue,
 			start: null,

--- a/lib/stream/leo-stream.js
+++ b/lib/stream/leo-stream.js
@@ -174,10 +174,7 @@ module.exports = function(configure) {
 				}
 			}).done().catch(err => {
 				uploadDonePromiseError = err;
-				if (toS3Stream) {
-					emittedError = true;
-					toS3Stream.emit("error", uploadDonePromiseError);
-				}
+				emittedError = true;
 			});
 
 			toS3Stream = write((s, enc, done) => {

--- a/lib/stream/leo-stream.js
+++ b/lib/stream/leo-stream.js
@@ -174,7 +174,10 @@ module.exports = function(configure) {
 				}
 			}).done().catch(err => {
 				uploadDonePromiseError = err;
-				emittedError = true;
+				if (toS3Stream) {
+					emittedError = true;
+					toS3Stream.emit("error", uploadDonePromiseError);
+				}
 			});
 
 			toS3Stream = write((s, enc, done) => {


### PR DESCRIPTION
## Summary

- Add error listener on internal S3 upload stream in `leos3.js` so `emit("error")` from `toS3()` has a handler and doesn't throw
- Listen for both `error` and `finish` events in `submitStream()` with a callback guard, since `_final(callback)` with a truthy error emits `error` not `finish`

## Task Reference
- Jira: https://chb.atlassian.net/browse/ES-2976

## Changes Made
- `lib/stream/helper/leos3.js` — Add `.on('error')` handler when creating the S3 stream in `newStream()`, and handle both `error`/`finish` events in `submitStream()`

## Root Cause

When an S3 upload fails (e.g., `RequestTimeout`), `toS3()`'s `.catch()` calls `toS3Stream.emit("error", err)`. In `leos3.js`, the internal `s3 = ls.toS3(...)` stream had no error listener, so `emit("error")` throws (Node.js EventEmitter behavior). Since the throw happens inside a `.catch()` handler, it creates a new unhandled promise rejection → `Runtime.ExitError` → Lambda crash.

## Testing
- Validated in staging against account 1000014534 which triggers this error every ~15 minutes