### PR TITLE
Update lodash to 4.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"ini": "2.0.0",
 				"leo-config": "1.1.0",
 				"leo-logger": "1.0.7",
-				"lodash": "4.17.21",
+				"lodash": "4.18.1",
 				"lodash.merge": "^4.6.2",
 				"moment": "2.29.4",
 				"pump": "3.0.0",
@@ -6468,7 +6468,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.escaperegexp": {
@@ -13638,7 +13640,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.21"
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
 		},
 		"lodash.escaperegexp": {
 			"version": "4.1.2"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"ini": "2.0.0",
 		"leo-config": "1.1.0",
 		"leo-logger": "1.0.7",
-		"lodash": "4.17.21",
+		"lodash": "4.18.1",
 		"lodash.merge": "^4.6.2",
 		"moment": "2.29.4",
 		"pump": "3.0.0",


### PR DESCRIPTION
## Summary
- Bump `lodash` from 4.17.21 to 4.18.1 (pinned exact version) in `package.json` and `package-lock.json`

## Test plan
- [x] All 242 unit tests pass via `npm run utest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only patch/minor bump with lockfile sync; risk is limited to lodash behavior changes across the codebase that already depends on it.
> 
> **Overview**
> Bumps the pinned **`lodash`** dependency from **4.17.21** to **4.18.1** in `package.json` and refreshes the matching lockfile entries in `package-lock.json` (version, resolved URL, and integrity hash). No application source changes are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b01faf222ae01b3bf008044d80f80c77fbb8da15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->