### PR TITLE
fix(wrappers/cron): don't leave an unhandled rejection when a bot promise rejects

### DIFF
--- a/wrappers/cron.js
+++ b/wrappers/cron.js
@@ -180,24 +180,34 @@ module.exports = function(configOverride, botHandler) {
 									callback(null, err || data);
 								});
 							});
-							if (promise && typeof promise.then == "function" && botHandler.length < 3) {
-								promise.then(data => {
-									cmdLogger.log("[LEOCRON]:complete:" + cronkey);
-									cron.reportComplete(event.__cron, context.awsRequestId, err ? "error" : "complete", err ? err : '', {}, function(err2, data2) {
-										if (err || err2) {
-											logger.log(err || err2);
-										}
-										callback(null, err || data);
-									});
+							// A rejection needs exactly one handler. Attaching .then() and .catch()
+							// to the same promise made them siblings rather than a chain: on
+							// rejection the .catch() reported the bot complete, but the
+							// .then()-derived chain stayed unhandled, and Node's default
+							// unhandledRejection mode ("throw") then killed the process after the
+							// bot had already been reported complete. Passing the rejection
+							// handler as then()'s second argument keeps the previous behaviour of
+							// both branches while leaving no unhandled chain behind.
+							let onRejected = err => {
+								cmdLogger.log("[LEOCRON]:complete:" + cronkey);
+								cron.reportComplete(event.__cron, context.awsRequestId, "error", err, {}, function() {
+									callback(null, err);
 								});
-							}
-							if (promise && typeof promise.catch == "function") {
-								promise.catch(err => {
-									cmdLogger.log("[LEOCRON]:complete:" + cronkey);
-									cron.reportComplete(event.__cron, context.awsRequestId, "error", err, {}, function() {
-										callback(null, err);
-									});
-								});
+							};
+							if (promise && typeof promise.then == "function") {
+								if (botHandler.length < 3) {
+									promise.then(data => {
+										cmdLogger.log("[LEOCRON]:complete:" + cronkey);
+										cron.reportComplete(event.__cron, context.awsRequestId, err ? "error" : "complete", err ? err : '', {}, function(err2, data2) {
+											if (err || err2) {
+												logger.log(err || err2);
+											}
+											callback(null, err || data);
+										});
+									}, onRejected);
+								} else if (typeof promise.catch == "function") {
+									promise.catch(onRejected);
+								}
 							}
 						}).catch(err => {
 							cron.reportComplete(event.__cron, context.awsRequestId, "error", err, {}, function() {


### PR DESCRIPTION
## Problem

When a bot handler returns a promise, `wrappers/cron.js` attaches **both** `promise.then(...)` and `promise.catch(...)` to the *same* promise:

```js
if (promise && typeof promise.then == "function" && botHandler.length < 3) {
    promise.then(data => { /* report complete */ });   // no rejection handler
}
if (promise && typeof promise.catch == "function") {
    promise.catch(err => { /* report error */ });       // attached to `promise`, not to the .then() chain
}
```

Those two are **siblings, not a chain**. When the handler's promise rejects, there are two outcomes:

1. The `.catch()` chain handles it correctly — logs `[LEOCRON]:complete` and reports status `"error"`.
2. The `.then()`-derived chain *also* rejects, and **nothing handles it**.

Node's default unhandled-rejection mode is `throw`, and in that mode the rejection is first delivered to any `unhandledRejection` listeners before being raised as an exception. The Lambda runtime registers one — `/var/runtime/index.mjs:1448`, visible in the crash stack — which reports `Runtime.UnhandledPromiseRejection` and exits the process. The SDK never registers an `unhandledRejection` listener of its own, so the orphaned chain is fatal. (The wrapper's removal of `uncaughtException` listeners at lines 61-63 plays no role here; that path is never reached.)

On Lambda this surfaces as `Runtime.UnhandledPromiseRejection` → `Runtime.ExitError`, killing the sandbox mid-write — see below for what that costs.

## Observed in production

A bot whose write stream exhausted its retries (leo-sdk's `toLeo` calls back with the bare string `'failed'`) produced this sequence — note the ordering, which shows leo's error branch *starting* and then the process being killed 5ms later:

```
20:28:35.238  ERROR  global "failed"                                       ← bot logged the rejection
20:28:35.239  INFO   [LEOCRON]:complete:…-media-switcher:0:…               ← the .catch() branch's log line
20:28:35.244  ERROR  Unhandled Promise Rejection
                     {"errorType":"Runtime.UnhandledPromiseRejection",
                      "errorMessage":"failed","reason":"failed", …}         ← the orphaned .then() chain
REPORT  Duration: 74747.77 ms  …  Status: error  Error Type: Runtime.ExitError
```

**The error report never actually lands.** The `[LEOCRON]:complete` line is only the log statement; the `reportComplete` DynamoDB write behind it is killed in flight when the process exits 5ms later, so the error status is never recorded and the cron lock is never released. CloudWatch shows the consequence: this run acquired its lock at 20:27:21.9 with a 300s Lambda timeout, and the next invocation arrived at 20:32:22.2 — exactly at lock expiry — where the normal cadence is back-to-back re-invocation within a second. (The preceding crash shows the same pattern to the second: lock at 20:22:20.5 → next run 20:27:21.9.) So each rejection today costs the real error report, ~4 minutes of the bot stalled on a dead lock, and a destroyed sandbox / cold start. This bot has been hitting it 1–6 times per day since at least July 26.

This is not specific to that `'failed'` value. The `botHandler.length < 3` gate means **any** `botWrapper(async (settings, context) => …)` bot gets the orphaned `.then()`, so **any** rejection from **any** async bot handler becomes a fatal `Runtime.ExitError` on top of the SDK's own correct error reporting.

Present on `master` and unchanged across at least 7.1.8 → 7.1.21.

## Fix

Pass the rejection handler as the **second argument to `then()`** instead of attaching a separate `.catch()`. A rejection then has exactly one handler and no orphaned chain, while both existing branches keep their current behaviour:

- `botHandler.length < 3` → success path plus error reporting.
- 3-arg (callback-style) handlers → still only the rejection path, since they report their own success through the callback.

Using `then(onFulfilled, onRejected)` rather than `.then().catch()` is deliberate: it keeps `onRejected` scoped to a rejection *of the handler's promise*, so a throw inside the success path isn't newly rerouted into the error branch. That keeps this change behaviour-preserving apart from removing the crash.

## Behavioural note worth flagging for reviewers

Today a rejection *attempts* `reportComplete("error")` but the write is killed in flight (see above) — so in practice the failure is visible **only** in the Lambda `Errors` metric, while the LeoCron error record is lost and the lock stalls the bot until expiry. After this change the Lambda no longer fails — it calls `callback(null, err)`, exactly as the existing callback-style path at line 176-181 already does, and the LeoCron error record reliably persists.

That is consistent with the SDK's design (bot errors are reported through the cron record, not through Lambda failure), but it does mean **these failures stop appearing in the Lambda `Errors` metric** and show up only via the LeoCron `errorCount` / botmon. Anyone alerting on Lambda errors for async bots would see those alarms go quiet — though as of 2026-08-08 neither affected function found so far (`media-service-prod-media-switcher`, `item-prod-item-aux-update-catalog`) has a CloudWatch alarm on it. I think consistency with the callback path is the right call, but it's a real monitoring change and I'd rather surface it than have it discovered later.

## Testing

- `npm run compile && mocha "test/*.utest.js"` → **297 passing, 0 failures**
- `node --check wrappers/cron.js` clean; `npx eslint wrappers/cron.js` clean

I did not add a unit test for this. `wrappers/cron.js` currently has no test coverage, and `lib/mock-sdk.md` states the position explicitly — *"Don't test the wrapper — it's framework plumbing"* — noting that the wrapper "creates its own internal SDK instance which cannot be swapped out." Testing it would need `require`-level interception of `../index.js`, which isn't a pattern used anywhere in the suite today. Happy to add one if you'd like, and #212 looks like the natural home for that kind of harness.

## Notes

- No Jira key on the branch, since I don't have access to the `ES` project — feel free to retitle if you want one attached.
- Separate, untouched observation: the `err` referenced inside the `then()` success handler resolves to the enclosing `cron.checkLock` callback's `err` (line 161), not the handler's error. It's always falsy on that path, so the current behaviour is correct, but it reads as though it were the handler's error. Left alone to keep this diff surgical.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core cron/Lambda completion plumbing for all async bots; behavior change stops Lambda invocation failures on handler promise rejections, which can affect error-based alerting even though cron error reporting is unchanged.
> 
> **Overview**
> Fixes a **fatal `Runtime.ExitError`** on async cron bots when the handler’s promise rejects.
> 
> Previously `wrappers/cron.js` attached separate `promise.then()` and `promise.catch()` on the same promise. On rejection, `.catch()` reported cron complete with `"error"`, but the `.then()`-derived chain stayed unhandled and Node’s default unhandled-rejection behavior could kill the Lambda after the bot was already marked complete.
> 
> The change wires rejections through **`promise.then(onFulfilled, onRejected)`** (shared `onRejected` helper) for handlers with `botHandler.length < 3`, and uses **only** `.catch(onRejected)` for three-argument callback-style handlers. That preserves the existing success vs error reporting paths without an orphaned rejection chain.
> 
> After the fix, rejected async bots finish via `callback(null, err)` like the callback path instead of also failing the invocation—so **Lambda `Errors` metrics may drop** for these cases while cron/botmon error reporting remains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b62327782f5210de32222be707753eeb8d1a049c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
